### PR TITLE
allow supplying a slack channel's name as a query parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ jspm_packages
 config.json
 .vscode
 upsource-slack.sublime-workspace
+
+# phpstorm
+.idea

--- a/adapters/discussion-feed-event.js
+++ b/adapters/discussion-feed-event.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-module.exports = function(review) {
+module.exports = function(review, channel) {
 	const reviewers = _.chain(review).get('data.base.userIds', []).map('userName').value().join(', ');
 
 	return {

--- a/app.js
+++ b/app.js
@@ -1,18 +1,24 @@
-const config = require('./config.json');
-const axios = require('axios');
+const config   = require('./config.json');
+const axios    = require('axios');
 const Adapters = require('./adapters');
-const _ = require('lodash');
+const _        = require('lodash');
+const Maybe    = require('maybe');
 
 module.exports = {
-	talkToSlack: function(review) {
+	talkToSlack: function(review, query) {
+
 		const adapter = Adapters[review.dataType];
+		var channel   = Maybe(query.channel);
 
 		if (_.isUndefined(adapter)) {
 			console.log(`No adapter has been registered for the event ${review.dataType}`);
 			return;
 		}
-
-		axios.post(config.slackWebhookUrl, adapter(review));
+		var adapted = adapter(review);
+		if(channel.isJust()) {
+			adapted.channel = "#"+channel.value()
+		}
+		axios.post(config.slackWebhookUrl, adapted);
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var app = require('./app');
 server.use(bodyParser.json());
 
 server.post('/', function (req, res) {
-  app.talkToSlack(req.body);
+  app.talkToSlack(req.body, req.query);
   res.end();
 });
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Upsource to Slack translator",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node index.js"
   },
   "author": "",
   "license": "ISC",
@@ -12,9 +12,7 @@
     "axios": "^0.12.0",
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "lodash": "^4.13.1"
-  },
-  "scripts": {
-    "start": "node index.js"
+    "lodash": "^4.13.1",
+    "maybe": "0.0.2"
   }
 }


### PR DESCRIPTION
Hey man,

I've added an option to supply channel name as a query parameter, the usage is as follow

`http://endpoint.address.domain:4000?channel=channel-name-without-hash`

the motivation was to be able to expose a single endpoint and use it for the lots of channels we have under our slack.

Please review the codes, expressjs and node are not my day-to-day techs.
Thanks!