### PR TITLE
Handle participant.userName undefined

### DIFF
--- a/adapters/participant-in-review-feed-event.js
+++ b/adapters/participant-in-review-feed-event.js
@@ -13,6 +13,9 @@ module.exports = function(review) {
 	if(review.dataType === "RemovedParticipantFromReviewFeedEventBean") {
 		const formerRole = review.data.formerRole;
 		let participant = review.data.participant.userName;
+		if(participant === undefined) {
+			participant = review.data.participant.userId;
+		}
 		return {
 			text: `Review #${review.data.base.reviewNumber}: ${participant} is no longer a ${reviewState[formerRole]}`,
 			attachments: [
@@ -41,6 +44,9 @@ module.exports = function(review) {
 	} else if (review.dataType === "NewParticipantInReviewFeedEventBean") {
 		const role = review.data.role;
 		let participant = review.data.participant.userName;
+		if(participant === undefined) {
+			participant = review.data.participant.userId;
+		}
 		return {
 			text: `Review #${review.data.base.reviewNumber}: ${participant} is now a ${reviewState[role]}`,
 			attachments: [

--- a/adapters/participant-state-changed-feed-event.js
+++ b/adapters/participant-state-changed-feed-event.js
@@ -1,8 +1,8 @@
 const _ = require('lodash');
 
 module.exports = function(review) {
+	"use strict";
 	const reviewers = _.chain(review).get('data.base.userIds', []).map('userName').value().join(', ');
-	const participant = review.data.participant.userName;
 	const reviewState  = {
 		0: '_Unread_',
 		1: '_Read_',
@@ -15,6 +15,11 @@ module.exports = function(review) {
 
 		return '#2AB27B'
 	});
+
+	let participant = review.data.participant.userName;
+	if(participant === undefined) {
+		participant = review.data.participant.userId;
+	}
 
 	return {
 		text: `Review #${review.data.base.reviewNumber}: ${participant} changed state from ${reviewState[review.data.oldState]} to ${reviewState[review.data.newState]}`,


### PR DESCRIPTION
When the participant is not defined in Upsource as a user, the `participant.userName` field is undefined. Handle this situation by falling back to the `userId`.